### PR TITLE
Added catalan translation of messages.xlf

### DIFF
--- a/messages.ca.xlf
+++ b/messages.ca.xlf
@@ -1,0 +1,6084 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" target-language="ca" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="MainTitle" datatype="html">
+        <source>SOTA Results and Summits Database</source>
+        <target state="new">Base de dades de resultats i cims SOTA</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Menu" datatype="html">
+        <source>Menu</source>
+        <target state="new">Menú</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Home" datatype="html">
+        <source>Home</source>
+        <target state="new">Inici</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="UserAccount" datatype="html">
+        <source>User Account</source>
+        <target state="new">Compte d'usuari</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ViewResults" datatype="html">
+        <source>View Results</source>
+        <target state="new">Mostra resultats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Summits" datatype="html">
+        <source>Summits</source>
+        <target state="new">Cims</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SubmitLogs" datatype="html">
+        <source>Submit Logs</source>
+        <target state="new">Enviar llibres de guàrdia</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Login" datatype="html">
+        <source>Login</source>
+        <target state="new">Ingrés</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/login-display/login-display.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="UpdateProfile" datatype="html">
+        <source>Update Profile</source>
+        <target state="new">Actualitza perfil</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="FactsAndFigures" datatype="html">
+        <source>Facts and Figures</source>
+        <target state="new">Dades i xifres</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorRollOfHonour" datatype="html">
+        <source>Activator Roll of Honour</source>
+        <target state="new">Llista d'honor d'activadors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorUniques" datatype="html">
+        <source>Activator Uniques</source>
+        <target state="new">Únics d'activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChaserRollOfHonour" datatype="html">
+        <source>Chaser Roll of Honour</source>
+        <target state="new">Llista d'honor de caçadors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChaserUniques" datatype="html">
+        <source>Chaser Uniques</source>
+        <target state="new">Únics de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="S2SRollOfHonour" datatype="html">
+        <source>Summit to Summit Roll of Honour</source>
+        <target state="new">Llista d'honor cim a cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SOTACompleteRoll" datatype="html">
+        <source>SOTA Complete Roll of Honour</source>
+        <target state="new">Llista d'honor de SOTA completats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SWLRoll" datatype="html">
+        <source>SWL Roll of Honour</source>
+        <target state="new">Llista d'honor de radiooïdors SWL</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Challenges" datatype="html">
+        <source>Challenges</source>
+        <target state="new">Reptes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyResults" datatype="html">
+        <source>My Results</source>
+        <target state="new">Els meus resultats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1st12mActivator" datatype="html">
+        <source>1st 12m Challenge Activator Roll of Honour</source>
+        <target state="new">Llista d'honor d'activadors del 1r Repte en 12m</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1st12mChaser" datatype="html">
+        <source>1st 12m Challenge Chaser Roll of Honour</source>
+        <target state="new">Llista d'honor de caçadors del 1r Repte en 12m</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1st610Activator" datatype="html">
+        <source>1st 6m/10m Challenge Activator Roll of Honour</source>
+        <target state="new">Llista d'honor d'activadors del 1r Repte en 6m/10m</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">89</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-activator/first610m-activator.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1st610Chaser" datatype="html">
+        <source>1st 6m/10m Challenge Chaser Roll of Honour</source>
+        <target state="new">Llista d'honor de caçadors del 1r Repte en 6m/10m</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2020SOTAChallengeActivator" datatype="html">
+        <source>2020 SOTA Challenge Activator Roll of Honour</source>
+        <target state="new">2020 Llista d'honor d'activadors del Repte SOTA</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2020SOTAChallengeChaser" datatype="html">
+        <source>2020 SOTA Challenge Chaser Roll of Honour</source>
+        <target state="new">2020 Llista d'honor de caçadors del Repte SOTA</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyActivatorLog" datatype="html">
+        <source>My Activator Log</source>
+        <target state="new">El meu llibre de guàrdia d'activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">104</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyActivatorUniques" datatype="html">
+        <source>My Activator Uniques</source>
+        <target state="new">Els meus únics d'activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">108</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyActivatorRegions" datatype="html">
+        <source>My Activator Regions</source>
+        <target state="new">Les meves regions d'activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">112</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-regions/my-activator-regions.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyChaserLog" datatype="html">
+        <source>My Chaser Log</source>
+        <target state="new">El meu llibre de guàrdia de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyChaserUniques" datatype="html">
+        <source>My Chaser Uniques</source>
+        <target state="new">Els meus únics de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyChaserRegions" datatype="html">
+        <source>My Chaser Regions</source>
+        <target state="new">Les meves regions de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">124</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyS2SLog" datatype="html">
+        <source>My S2S Log</source>
+        <target state="new">El meu llibre de guàrdia cim a cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MySOTAComplete" datatype="html">
+        <source>My SOTA Complete Log</source>
+        <target state="new">El meu llibre de guàrdia de SOTA completats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">132</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyMicrowaveActivator" datatype="html">
+        <source>My Microwave Activator Log</source>
+        <target state="new">El meu llibre de guàrdia d'activador en microones</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">136</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyMicrowaveChaser" datatype="html">
+        <source>My Microwave Chaser Log</source>
+        <target state="new">El meu llibre de guàrdia de caçador en microones</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">140</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyMicrowaveS2S" datatype="html">
+        <source>My Microwave S2S Log</source>
+        <target state="new">El meu llibre de guàrdia cim a cim en microones</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">144</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MySWLLog" datatype="html">
+        <source>My SWL Log</source>
+        <target state="new">El meu llibre de guàrdia de radiooïdor SWL</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">148</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyAwards" datatype="html">
+        <source>My Awards</source>
+        <target state="new">Els meus premis</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">152</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-awards/my-awards.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyStatistics" datatype="html">
+        <source>My Statistics</source>
+        <target state="new">Les meves estadístiques</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">156</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SummitList" datatype="html">
+        <source>List of all summits</source>
+        <target state="new">Llista de tots els cims</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">163</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="FindSummits" datatype="html">
+        <source>Find summits</source>
+        <target state="new">Troba cims</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">167</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="PopularSummits" datatype="html">
+        <source>Popular summits</source>
+        <target state="new">Cims populars</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">171</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="RecentSummits" datatype="html">
+        <source>Recently activated summits</source>
+        <target state="new">Cims activats més recentment</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">175</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SubmitActivator" datatype="html">
+        <source>Submit Activator Entry</source>
+        <target state="new">Enviar entrada d'activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">184</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SubmitChaserS2S" datatype="html">
+        <source>Submit Chaser/S2S Entry</source>
+        <target state="new">Enviar entrada de caçador o cim-a-cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">188</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="UploadCSV" datatype="html">
+        <source>Upload CSV/TSV log file</source>
+        <target state="new">Pujar llibre de guàrdia CSV/TSV</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">192</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="UploadADIF" datatype="html">
+        <source>Upload ADIF log file</source>
+        <target state="new">Pujar llibre de guàrdia ADIF</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">196</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ManageUploads" datatype="html">
+        <source>Manage Uploads</source>
+        <target state="new">Gestionar fitxers pujarts</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/menu/menu.component.html</context>
+          <context context-type="linenumber">200</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TitlePageWelcome" datatype="html">
+        <source>
+Welcome to the Worldwide Summits On The Air database service.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/title-page/title-page.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TitlePageSOTA" datatype="html">
+        <source>
+Summits on the Air is a programme that encourages radio amateurs who enjoy hill walking and the great outdoors to take their radios with them and operate from the mountain tops.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/title-page/title-page.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TitlePageAward" datatype="html">
+        <source>
+An award scheme recognises those who activate the summits and also those that make QSOs with the activators. The programme can be operated anywhere in the world.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/title-page/title-page.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TitlePageInfo" datatype="html">
+        <source>
+For more information about the SOTA program in your area, please see the main website, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>https://www.sota.org.uk<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/title-page/title-page.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SOTACompetition" datatype="html">
+        <source>SOTA is not inherently a competitive activity, it's about individual aspirations and working towards a goal at your own pace. However, it can be fun to see how your progress compares with that of others, hence we publish our Honour Roll on the internet.</source>
+        <target state="new">SOTA no és inherentment una activitat competitiva; té a veure sobretot amb les vostres aspiracions individuals i amb com treballar cap a un objectiu al vostre ritme propi. Tot i això, pot ser divertit comparar el vostre progrés amb el d'altres; per això publiquem la nostra llista d'honor en Internet.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-chaser/first610m-chaser.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-activator/first610m-activator.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SOTAPleaseSubmit" datatype="html">
+        <source>
+Please help us to keep this page up-to-date by regularly submitting your SOTA logs.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="AllAssociations" datatype="html">
+        <source>All Associations</source>
+        <target state="new">Totes  les associacions</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="All" datatype="html">
+        <source>All</source>
+        <target state="new">Tot</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Association" datatype="html">
+        <source>Association</source>
+        <target state="new">Associació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">112</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">110</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-chaser/first610m-chaser.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-activator/first610m-activator.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Year" datatype="html">
+        <source>Year</source>
+        <target state="new">Any</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="AllBands" datatype="html">
+        <source>All Bands</source>
+        <target state="new">Totes les  bandes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Band" datatype="html">
+        <source>Band</source>
+        <target state="new">Banda</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="AllModes" datatype="html">
+        <source>All Modes</source>
+        <target state="new">Tots els modes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Modes" datatype="html">
+        <source>Modes</source>
+        <target state="new">Modes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Show" datatype="html">
+        <source>Show</source>
+        <target state="new">Mostra</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Position" datatype="html">
+        <source> Position </source>
+        <target state="new">Posició</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">126</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">150</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChaserCallsign" datatype="html">
+        <source> Chaser Callsign </source>
+        <target state="new">Indicatiu de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorsWorked" datatype="html">
+        <source> Activators Worked </source>
+        <target state="new">Activadors contactats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Points" datatype="html">
+        <source> Points </source>
+        <target state="new">Punts</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">163</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">162</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">146</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">150</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">162</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-chaser/first610m-chaser.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-activator/first610m-activator.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Average" datatype="html">
+        <source> Average </source>
+        <target state="new">Mitjana</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ViewLog" datatype="html">
+        <source> View Log </source>
+        <target state="new">Mostra llibre de guàrdia</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="View" datatype="html">
+        <source>View</source>
+        <target state="new">Mostra</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="NoResultsFound" datatype="html">
+        <source>No results found</source>
+        <target state="new">No 'han trobat resultats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-roll/chaser-roll.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">80</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sroll/s2-sroll.component.html</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="DatabaseStatistics" datatype="html">
+        <source>Database statistics</source>
+        <target state="new">Estadístiques de base de dades</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="RegisteredUsers" datatype="html">
+        <source>Registered Users</source>
+        <target state="new">Usuaris inscrits</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Associations" datatype="html">
+        <source>Associations</source>
+        <target state="new">Associacions</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Regions" datatype="html">
+        <source>Regions</source>
+        <target state="new">Regions</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="WebpageHits" datatype="html">
+        <source>Webpage Hits since 10 Jan 2004</source>
+        <target state="new">Visites a la pàgina web després del 10 de gener de 2004</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorStatistics" datatype="html">
+        <source>Activator statistics</source>
+        <target state="new">Estadístiques d'activadors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="NumberActivators" datatype="html">
+        <source>Number of Activators</source>
+        <target state="new">Nombre d'activadors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatedSummits" datatype="html">
+        <source>Activated Summits</source>
+        <target state="new">Cims activats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="NumberActivations" datatype="html">
+        <source>Number of Activations</source>
+        <target state="new">Nombre d'activacions</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="NumberQSOs" datatype="html">
+        <source>Number of QSOs</source>
+        <target state="new">Nombre de QSOs</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TotalActivatorPoints" datatype="html">
+        <source>Total Activator Points</source>
+        <target state="new">Total de punts d'activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorQSOsByMode" datatype="html">
+        <source>Activator QSOs by Mode</source>
+        <target state="new">QSOs d'activador per mode</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorQSOsByBand" datatype="html">
+        <source>Activator QSOs by Band</source>
+        <target state="new">QSOs d'activador per banda</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Chasers" datatype="html">
+        <source>Chasers</source>
+        <target state="new">Caçadors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="NumberOfChasers" datatype="html">
+        <source>Number of Chasers</source>
+        <target state="new">Nombre de caçadors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChaserActivators" datatype="html">
+        <source>Chasers who are also activators</source>
+        <target state="new">Caçadors que són també activadors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="NumberChaserContacts" datatype="html">
+        <source>Number of Chaser Contacts</source>
+        <target state="new">Nombre de contactes de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TotalChaserPoints" datatype="html">
+        <source>Total Chaser Points</source>
+        <target state="new">Total de punts de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="S2S" datatype="html">
+        <source>Summit to Summit</source>
+        <target state="new">Cim a cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="S2SContacts" datatype="html">
+        <source>Summit to Summit Contacts</source>
+        <target state="new">Contactes cim a cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="S2SPoints" datatype="html">
+        <source>Summit to Summit Points</source>
+        <target state="new">Punts cim a cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/facts-and-figures/facts-and-figures.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorCallsign" datatype="html">
+        <source> Activator Callsign </source>
+        <target state="new">Indicatiu d'activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">154</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">110</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="BonusPoints" datatype="html">
+        <source> Bonus Points </source>
+        <target state="new">Punts extra</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TotalPoints" datatype="html">
+        <source> Total Points </source>
+        <target state="new">Punts totals</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-roll/activator-roll.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Callsign" datatype="html">
+        <source> Callsign </source>
+        <target state="new">Indicatiu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-roll/completes-roll.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-chaser/first610m-chaser.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-activator/first610m-activator.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/generate-awards/generate-awards.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="UniqueSummits" datatype="html">
+        <source> Unique Summits </source>
+        <target state="new">Cims únics</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TotalSummits" datatype="html">
+        <source> Total Summits </source>
+        <target state="new">Total de cims</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-regions/my-chaser-regions.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-regions/my-activator-regions.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="PercentUnique" datatype="html">
+        <source> Percent Unique </source>
+        <target state="new">Percentatge d'únics</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques/activator-uniques.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvUp1" datatype="html">
+        <source>
+You can use this page to perform a bulk upload of many Activator, Chaser and S2S Entries at
+once. This page is intended for more experienced users only.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvUp2" datatype="html">
+        <source>If you have a large number of log entries you want to claim, this may be the fastest way of recording them
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvUp3" datatype="html">
+        <source>
+If however you only have a dozen or less entries, it will probably be easier 
+to use the normal <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Add Activation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> or <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a&gt;"/>Add Chaser/S2S<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> web pages.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Instructions" datatype="html">
+        <source>Instructions</source>
+        <target state="new">Instruccions</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvUpInst1" datatype="html">
+        <source>
+	Create a CSV or TSV file containing all your entries. These can be for any number of activations. The file can be generated using a text editor such as 
+NOTEPAD, or can be exported from many other programs, such as Microsoft Excel. 
+The format of this file is critical to ensure that correct log entries are recorded. Click <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>here<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for details of the format of the CSV file that we require.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvUpInst2" datatype="html">
+        <source>
+	If you are unsure what a CSV or TSV file is, please use the normal <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>activator<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> or <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a&gt;"/>chaser<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> data entry page instead.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvUpInst3" datatype="html">
+        <source>
+	Press the Browse button below and select the CSV or TSV file on your hard drive
+   </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvUpInst4" datatype="html">
+        <source>
+	Press the Upload File button on the bottom of this screen to transfer the file to our server and begin processing it. This may take a few seconds. Please be patient!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="selectCSV" datatype="html">
+        <source>Select CSV File:</source>
+        <target state="new">Seleccioneu arxiu de CSV:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Date" datatype="html">
+        <source> Date </source>
+        <target state="new">Data</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Time" datatype="html">
+        <source> Time </source>
+        <target state="new">Hora</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">103</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Mode" datatype="html">
+        <source> Mode </source>
+        <target state="new"> Mode </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">115</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">222</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Summit" datatype="html">
+        <source> Summit </source>
+        <target state="new">Cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">129</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">132</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">171</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">174</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">158</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">170</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="OtherSummit" datatype="html">
+        <source> Other Summit </source>
+        <target state="new">L'altre cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">240</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="OtherCallsign" datatype="html">
+        <source> Other Callsign </source>
+        <target state="new">L'altre indicatiu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">231</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Duplicate" datatype="html">
+        <source> Duplicate? </source>
+        <target state="new">Duplicat?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Comment" datatype="html">
+        <source> Comment </source>
+        <target state="new">Comentari</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="IsS2S" datatype="html">
+        <source> Is S2S? </source>
+        <target state="new">És cim a cim?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">85</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="IsI18N" datatype="html">
+        <source> Is Chaser Entry? </source>
+        <target state="new">És un registre de caçador?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">89</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="uploadError" datatype="html">
+        <source>There are errors in your file - please correct them and try again</source>
+        <target state="new">Hi ha errors en el vostre arxiu - si us plau, corregiu-los i proveu una altra vegada</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Cancel" datatype="html">
+        <source>Cancel</source>
+        <target state="new">Cancel·la</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">148</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">100</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">117</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="uploadVerify" datatype="html">
+        <source>Please verify the uploaded details and click Submit when ready</source>
+        <target state="new">Si us plau verifiqueu la informació que heu pujat i feu clic en Envia en acabar.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">100</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Submit" datatype="html">
+        <source>Submit</source>
+        <target state="new">Envia</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">118</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">147</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">156</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvSpirit" datatype="html">
+        <source>
+By submitting this log, I certify that I have operated within the rules
+and spirit of the SOTA Programme. I agree that the decision of the
+Management Team will be final in any case of dispute.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">107</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">136</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">145</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">105</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvSpirit2" datatype="html">
+        <source>
+I understand that the scores shown on this website are for guidance only
+and that entries may be subject to verification and adjustment by the award
+administrators.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">112</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">141</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">150</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">110</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="IAgree" datatype="html">
+        <source>I agree</source>
+        <target state="new">D'acord</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">117</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">146</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">155</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">115</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="uploadAnother" datatype="html">
+        <source>Upload another log</source>
+        <target state="new">Pujar un altre llibre de guàrdia</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv/activator-csv.component.html</context>
+          <context context-type="linenumber">124</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">122</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SelectAssociation" datatype="html">
+        <source>Select Association</source>
+        <target state="new">Selecciona associació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Region" datatype="html">
+        <source>Region</source>
+        <target state="new">Regió</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">122</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">114</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SelectRegion" datatype="html">
+        <source>Select Region</source>
+        <target state="new">Selecciona regió</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SelectSummit" datatype="html">
+        <source>Select Summit</source>
+        <target state="new">Selecciona Cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivationDate" datatype="html">
+        <source>Date of activation</source>
+        <target state="new">Data d'activació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-sota-complete/my-sota-complete.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-show/completes-show.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChooseADate" datatype="html">
+        <source>Choose a date</source>
+        <target state="new">Trieu una data</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TimeUTC" datatype="html">
+        <source>Time (UTC)</source>
+        <target state="new">Hora (UTC)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="otherCallsign" datatype="html">
+        <source>Callsign</source>
+        <target state="new">Indicatiu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">107</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Notes" datatype="html">
+        <source>Notes</source>
+        <target state="new">Notes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">88</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">159</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">158</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="AddQSO" datatype="html">
+        <source>Add QSO</source>
+        <target state="new">Afegir QSO</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Comments" datatype="html">
+        <source> Comments </source>
+        <target state="new">Comentaris</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">251</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Delete" datatype="html">
+        <source> Delete </source>
+        <target state="new">Eliminar</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">123</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">124</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">180</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">186</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">187</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">179</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SubmitLog" datatype="html">
+        <source>Submit Log</source>
+        <target state="new">Enviar llibre de guàrdia</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">131</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">141</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="UploadAnother" datatype="html">
+        <source>Upload another log</source>
+        <target state="new">Pujar un altre llibre de guàrdia</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-activator/add-activator.component.html</context>
+          <context context-type="linenumber">153</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="FindSummit" datatype="html">
+        <source>Find a summit</source>
+        <target state="new">Trobar un cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/find-summit/find-summit.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="EnterSummitCode" datatype="html">
+        <source>Enter the name or code of a summit and press the &quot;Find&quot; button.</source>
+        <target state="new">Entreu el nom o codi d'una cimera i premeu el botó &quot;Troba&quot;.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/find-summit/find-summit.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Search" datatype="html">
+        <source>Search</source>
+        <target state="new">Cerca</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/find-summit/find-summit.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Find" datatype="html">
+        <source>Find</source>
+        <target state="new">Troba</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/find-summit/find-summit.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="FindSummitsFound" datatype="html">
+        <source>The following summits were found.  Select the one you wish to view</source>
+        <target state="new">S'han trobat els cims següents. Seleccioneu el que voleu veure</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/find-summit/find-summit.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SummitReference" datatype="html">
+        <source> Summit Reference </source>
+        <target state="new">Referència del cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/find-summit/find-summit.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Name" datatype="html">
+        <source> Name </source>
+        <target state="new">Nom</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/find-summit/find-summit.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">134</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/generate-awards/generate-awards.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Info" datatype="html">
+        <source> Info </source>
+        <target state="new">Info.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/find-summit/find-summit.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SummitInfo" datatype="html">
+        <source>Summit Info</source>
+        <target state="new">Info. del cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/find-summit/find-summit.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="AltM" datatype="html">
+        <source> Alt (m) </source>
+        <target state="new">Alt. (m)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="AltFt" datatype="html">
+        <source> Alt (ft) </source>
+        <target state="new">Alt, (peus)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivationCount" datatype="html">
+        <source> Activation Count </source>
+        <target state="new">Nombre d'activacions</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="LastActivation" datatype="html">
+        <source> Last Activation </source>
+        <target state="new">Darrera activació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="LastActivator" datatype="html">
+        <source> Last Activator </source>
+        <target state="new">Darrer activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/top-summits/top-summits.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/recent-summits/recent-summits.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SummitDetails" datatype="html">
+        <source>Summit Details</source>
+        <target state="new">Informació del cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="BySummitRef" datatype="html">
+        <source>by Summit Ref</source>
+        <target state="new">per referència del cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ByOldestActivation" datatype="html">
+        <source>by Oldest Activation</source>
+        <target state="new">per activació més antiga</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ByNewestActivation" datatype="html">
+        <source>by Newest Activation</source>
+        <target state="new">per activació més recent</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="DisplayOrder" datatype="html">
+        <source>Display Order</source>
+        <target state="new">Ordre de presentació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Details" datatype="html">
+        <source>Details</source>
+        <target state="new">Informació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="RegionName" datatype="html">
+        <source>Region Name: </source>
+        <target state="new">Nom de la regió:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="RegionCode" datatype="html">
+        <source>Region Code: </source>
+        <target state="new">Codi de la regió:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-regions/my-chaser-regions.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-regions/my-activator-regions.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="RegionManager" datatype="html">
+        <source>Region Manager:</source>
+        <target state="new">Coordinador de la regió:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Contact" datatype="html">
+        <source>Contact:</source>
+        <target state="new">Contacte:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="RegionMap" datatype="html">
+        <source>Region Map</source>
+        <target state="new">Mapa de la regió</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Latitude" datatype="html">
+        <source> Latitude </source>
+        <target state="new">Latitud</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Longitude" datatype="html">
+        <source> Longitude </source>
+        <target state="new">Longitud</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Locator" datatype="html">
+        <source> Locator </source>
+        <target state="new">Localitzador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="History" datatype="html">
+        <source> History </source>
+        <target state="new">Història</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">88</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SummitsListCSV" datatype="html">
+        <source>NOTE : You can download a CSV file containing a list of all summits by clicking <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>here<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
+    </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/list-summits/list-summits.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Percentage&lt;br/&gt;Unique" datatype="html">
+        <source> Percentage<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>Unique </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques/chaser-uniques.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="YourCallsign" datatype="html">
+        <source>Callsign/SWL YOU used</source>
+        <target state="new">Indicatiu/indicatiu SWL usat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="S2SQSO" datatype="html">
+        <source>S2S QSO</source>
+        <target state="new">QSO cim a cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SWL" datatype="html">
+        <source>SWL</source>
+        <target state="new">SWL</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">100</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MySummitDetails" datatype="html">
+        <source>My summit details</source>
+        <target state="new">Els meus detalls de cims</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ThankYou" datatype="html">
+        <source>
+Thank you for participating in SOTA
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">163</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="OK" datatype="html">
+        <source>OK</source>
+        <target state="new">D'acord</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="AddAnother" datatype="html">
+        <source>Add another</source>
+        <target state="new">Afegiu-ne un altre</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/add-chaser/add-chaser.component.html</context>
+          <context context-type="linenumber">167</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Last6Months" datatype="html">
+        <source>Last 6 Months</source>
+        <target state="new">Darrers 6 mesos</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Last12Months" datatype="html">
+        <source>Last 12 Months</source>
+        <target state="new">Últims 12 Mesos</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Jan" datatype="html">
+        <source>Jan</source>
+        <target state="new">Gen</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Dec" datatype="html">
+        <source>Dec</source>
+        <target state="new">Des</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Order" datatype="html">
+        <source>Order</source>
+        <target state="new">Orde</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="OwnCallsign" datatype="html">
+        <source> Own Callsign </source>
+        <target state="new">Indicatiu propi</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorWorked" datatype="html">
+        <source> Activator Worked </source>
+        <target state="new">Activador contactat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Total" datatype="html">
+        <source> Total </source>
+        <target state="new"> Total </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">167</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">170</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">154</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SummitName" datatype="html">
+        <source> Summit Name </source>
+        <target state="new">Nom del cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">175</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-sota-complete/my-sota-complete.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">114</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">174</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-show/completes-show.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="DeleteEntry" datatype="html">
+        <source> Delete Entry </source>
+        <target state="new">Esborrar entrada</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log/my-chaser-log.component.html</context>
+          <context context-type="linenumber">179</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-log-show/chaser-log-show.component.html</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ShowLog" datatype="html">
+        <source> Show Log </source>
+        <target state="new">Mostra llibre de guàrdia</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">179</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">162</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">163</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Download" datatype="html">
+        <source> Download </source>
+        <target state="new">Descarrega</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">182</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log/my-activator-log.component.html</context>
+          <context context-type="linenumber">183</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-log/activator-log.component.html</context>
+          <context context-type="linenumber">167</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Navigation" datatype="html">
+        <source>Navigation</source>
+        <target state="new">Navegació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Summary" datatype="html">
+        <source>Summary</source>
+        <target state="new">Resum</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Previous500" datatype="html">
+        <source>Previous 500</source>
+        <target state="new">500 anteriors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Next500" datatype="html">
+        <source>Next 500</source>
+        <target state="new">500 posteriors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Sort" datatype="html">
+        <source>Sort</source>
+        <target state="new">Ordena</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Number" datatype="html">
+        <source> Number </source>
+        <target state="new">Nombre</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Contacts" datatype="html">
+        <source> Contacts </source>
+        <target state="new">Contactes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-uniques/my-chaser-uniques.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-uniques-show/activator-uniques-show.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Count" datatype="html">
+        <source> Count </source>
+        <target state="new">Nombre</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-sota-complete/my-sota-complete.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-awards/my-awards.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-awards/my-awards.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-awards/my-awards.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-awards/my-awards.component.html</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">138</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">158</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/awards-show/awards-show.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/awards-show/awards-show.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/awards-show/awards-show.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/awards-show/awards-show.component.html</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-show/completes-show.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SummitCode" datatype="html">
+        <source> Summit Code </source>
+        <target state="new">Codi del cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-sota-complete/my-sota-complete.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">130</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-show/completes-show.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check/award-check.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/award-check-activator/award-check-activator.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChasedDate" datatype="html">
+        <source> Chased Date </source>
+        <target state="new">Data de caça</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-sota-complete/my-sota-complete.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-show/completes-show.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="CompletedDate" datatype="html">
+        <source> Completed Date </source>
+        <target state="new">Data d'acabament</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-sota-complete/my-sota-complete.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/completes-show/completes-show.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Activations" datatype="html">
+        <source> Activations </source>
+        <target state="new">Activacions</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-uniques/my-activator-uniques.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="awardsMG" datatype="html">
+        <source>You are a Mountain Goat with <x id="INTERPOLATION" equiv-text="{{statistics.mg.Points}}"/> points.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-awards/my-awards.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="achievedon" datatype="html">
+        <source>achieved on</source>
+        <target state="new">aconseguides en</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-awards/my-awards.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Association(s)Activated" datatype="html">
+        <source> Association(s) Activated </source>
+        <target state="new">Associació/ons activades</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-awards/my-awards.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-awards/my-awards.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/awards-show/awards-show.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivationStatistics" datatype="html">
+        <source>Activation Statistics</source>
+        <target state="new">Estadístiques d'activació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Score" datatype="html">
+        <source>Score</source>
+        <target state="new">Puntuació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TotalSummitsActivated" datatype="html">
+        <source>Total summits activated</source>
+        <target state="new">Total de cims activats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="UniqueSummitsActivated" datatype="html">
+        <source>Unique summits activated</source>
+        <target state="new">Cims únics activats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorCallsignsUsed" datatype="html">
+        <source> Activator Callsigns Used </source>
+        <target state="new">Indicatius d'activador usats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatedAssocsRegions" datatype="html">
+        <source>Activated associations and regions</source>
+        <target state="new">Associacions i regions activades</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TotalDiffChasers" datatype="html">
+        <source>Total different chaser callsigns worked as activator</source>
+        <target state="new">Total d'indicatius diferents contactats com a activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyTopActivatedSummits" datatype="html">
+        <source>My top activated summits</source>
+        <target state="new">Els meus cims més activats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyTopActivationChasers" datatype="html">
+        <source>My top activation chasers</source>
+        <target state="new">Els meus caçadors d'activació més freqüents</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChaserStatistics" datatype="html">
+        <source>Chaser Statistics</source>
+        <target state="new">Estadístiques de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChaserScore" datatype="html">
+        <source>Chaser Score</source>
+        <target state="new">Puntuació de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChaserCallsignsUsed" datatype="html">
+        <source> Chaser Callsigns Used </source>
+        <target state="new">Indicatius de caçador usats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChasedAssocsRegions" datatype="html">
+        <source>Chased associations and regions</source>
+        <target state="new">Associacions i regions caçades</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TotalDiffActivators" datatype="html">
+        <source>Total different activator callsigns worked as chaser</source>
+        <target state="new">Total d'indicatius diferents contactats com a caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">121</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyTopChasedSummits" datatype="html">
+        <source>My top chased summits</source>
+        <target state="new">Els meus cims més caçats.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">122</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyTopChasedActivators" datatype="html">
+        <source>My top chased activators</source>
+        <target state="new">Els meus activadors més caçats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-statistics/my-statistics.component.html</context>
+          <context context-type="linenumber">146</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyChaserRegoins" datatype="html">
+        <source>My Chased Regions</source>
+        <target state="new">Les meues regions caçades</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-regions/my-chaser-regions.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="%ageComplete" datatype="html">
+        <source> %age Complete </source>
+        <target state="new">%atge complet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-regions/my-chaser-regions.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-regions/my-activator-regions.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyActivatedSummits" datatype="html">
+        <source> My Activated Summits </source>
+        <target state="new">Cims que he activat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-regions/my-activator-regions.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Distance" datatype="html">
+        <source> Distance </source>
+        <target state="new">Distància</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChaserPoints" datatype="html">
+        <source> ChaserPoints </source>
+        <target state="new">Punts de caçador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatorPoints" datatype="html">
+        <source> Activator Points </source>
+        <target state="new">Punts d'activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChasedSummit" datatype="html">
+        <source> Chased Summit </source>
+        <target state="new">Cim caçat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">80</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ActivatedSummit" datatype="html">
+        <source> Activated Summit </source>
+        <target state="new">Cim activat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog/my-s2-slog.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/s2-sshow/s2-sshow.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="chaserDeleteResult2" datatype="html">
+        <source>You cannot delete this QSO.  The error received was: <x id="INTERPOLATION" equiv-text="{{this.resultText}}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="deleteChaser" datatype="html">
+        <source>
+You are about to permanently delete the record of the chaser contact below. This cannot be undone.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="deleteChaser2" datatype="html">
+        <source>
+If you wish to proceed, press the DELETE button at the bottom of this screen, otherwise press CANCEL.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="date" datatype="html">
+        <source>Date:</source>
+        <target state="new">Data:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="time" datatype="html">
+        <source>Time:</source>
+        <target state="new">Hora:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MySummit" datatype="html">
+        <source>My Summit</source>
+        <target state="new">El meu cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="chaserDeleteResult" datatype="html">
+        <source>Operation complete.  The response from the server was: <x id="INTERPOLATION" equiv-text="{{this.resultText}}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-chaser-log-delete/my-chaser-log-delete.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-s2-slog-delete/my-s2-slog-delete.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SOTAActivatorTSV/CSVfileformat" datatype="html">
+        <source>SOTA Activator and Chaser TSV/CSV file format</source>
+        <target state="new">Format TSV/CSV del fitxer de caçador i activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvOne" datatype="html">
+        <source>This facility lets you upload a large number of QSOs in one bulk
+        transaction. You need to create a Comma Separated Variable (CSV) or Tab
+        Separated Variable (TSV) file with the fields laid out as shown in the example
+        below. You then submit this file, which is checked for errors before presenting
+        you with the option to save the QSOs to your database. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>You can mix activation records,
+        chaser records and S2S (summit to summit) records all in the same file.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>
+        You can include multiple activations in this file but all records for each activation must be together.
+        Each activation is deemed to end when the [My Summit] reference changes. If you
+        activate the same summit on several days you must upload each activation in a separate file<x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/> otherwise
+        the file will be assumed to only contain a single activation.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>
+
+                 </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv2" datatype="html">
+        <source>The new prefered Version 2 (V2) format consists of upto ten fields as follows</source>
+        <target state="new">El nou format preferit de versió 2 (V2) consisteix en un màxim de 10 camps com s'explica</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv3" datatype="html">
+        <source>[V2] [My Callsign][My Summit] [Date] [Time]
+                [Band] [Mode] [His Callsign] </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="or" datatype="html">
+        <source>
+      or
+    </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv4" datatype="html">
+        <source>[V2] [My Callsign][My Summit] [Date] [Time]
+                [Band] [Mode] [His Callsign][His Summit] </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv5" datatype="html">
+        <source>[V2] [My Callsign][My Summit] [Date] [Time]
+                [Band] [Mode] [His Callsign][His Summit] [Notes or Comments]</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv6" datatype="html">
+        <source>Each field is separated by either a Comma (CSV) or Tab (TSV).
+        Each QSO is a single record and there is one record to a line, terminated in
+        [CR][LF].</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv7" datatype="html">
+        <source>Here is an example:</source>
+        <target state="new">Heus ací un exemple:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv8" datatype="html">
+        <source><x id="START_UNDERLINED_TEXT" ctype="x-u" equiv-text="&lt;u&gt;"/>Field notes<x id="CLOSE_UNDERLINED_TEXT" ctype="x-u" equiv-text="&lt;/u&gt;"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvField" datatype="html">
+        <source><x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>Field<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MyCallsign" datatype="html">
+        <source>My Callsign</source>
+        <target state="new">El meu indicatiu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvCallsign" datatype="html">
+        <source>This is the callsign <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>you<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/>
+              used for the QSO. No spaces in the callsign please</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvSummit" datatype="html">
+        <source>This MUST be the full
+              SOTA reference of the summit you where activating, as shown in the above example.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvSummitChaser" datatype="html">
+        <source>If you are entering a chaser log, this field will be blank.  See last entry in the example.
+          </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvDate" datatype="html">
+        <source>The date of the QSO.
+              Most date formats are accepted but be careful about USA vs. International date
+              format.  Use of International date format (DD/MM/YY) is recommended</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvTime" datatype="html">
+        <source>The time in UTC.
+              Either HHMM or HH:MM will work. Use the 24 hour clock!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvBand" datatype="html">
+        <source>You can enter the frequency in MHz (14.285MHz) or pick from the following:</source>
+        <target state="new">Podeu indicar la freqüència en MHz (14.285MHz) o elegir entre els següents:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">105</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvOtherCall" datatype="html">
+        <source>The callsign of the <x id="START_TAG_STRONG" ctype="x-STRONG" equiv-text="&lt;STRONG&gt;"/>
+                station worked<x id="CLOSE_TAG_STRONG" ctype="x-STRONG" equiv-text="&lt;/STRONG&gt;"/>.  No spaces in the callsign please</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">234</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvOtherSummit" datatype="html">
+        <source>This field is only needed if the station
+              was also activating a SOTA summit. This is the full SOTA reference of the summit the chasing station was activating, as shown in the above example.
+                            If there is no [Other Summit] you can leave this blank. If there is a comment then you must insert a TAB or comma to mark the field as being blank.
+                            See entries for G3NOH or GW4GTE</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">243</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csvComments" datatype="html">
+        <source>An optional field for
+              recording short notes about the QSO. This could include the Operator's name and
+              location, Signal Report, QSL information, or almost anything else. ,<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>You can embed a TAB or comma in this field. If you do you must enclose the entire Notes field in double-quotes. <x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>
+
+
+          </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">254</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv9" datatype="html">
+        <source>The easiest way to
+        create your TSV/CSV file is using Excel.  This allows you to arrange your
+        log data in columns then save it as either a TSV or CSV file.  Either is
+        accepted by the SOTA program.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">265</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="CommonErrors" datatype="html">
+        <source>Common errors</source>
+        <target state="new">Errades comunes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">270</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv10" datatype="html">
+        <source>Spaces in the
+            callsigns.  Our callsigns do not have spaces in them!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">273</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv11" datatype="html">
+        <source>Date or time out of
+            order.  The input parser will show an error if the log is not in
+            sequential order</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">276</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv12" datatype="html">
+        <source>Errors in the SOTA
+            reference number.  Spaces in the reference, leaving off the ITU prefix, or
+            specifying a reference that does not exist will all result in an error being
+            reported.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">280</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="csv13" datatype="html">
+        <source>If an error is
+        detected then it is shown in Red and you should then modify the file to correct
+        the error and resubmit it. Once you get an error free report, you should
+        carefully check that everything is correct before saving it. As soon as you
+        have saved the data you will be able to see the effect in the various Activator
+        tables.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-csv-help/activator-csv-help.component.html</context>
+          <context context-type="linenumber">286</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="MySWL" datatype="html">
+        <source> My SWL </source>
+        <target state="new">El meu indicatiu SWL</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="StationHeard" datatype="html">
+        <source> Station Heard </source>
+        <target state="new">Estació escoltada</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-swllog/my-swllog.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swllog-show/swllog-show.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Height" datatype="html">
+        <source>Height:</source>
+        <target state="new">Alturat:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ExtraInfo" datatype="html">
+        <source>Extra Info:</source>
+        <target state="new">Informació addicional:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SummitMap" datatype="html">
+        <source>Summit Map:</source>
+        <target state="new">Mapa del cim:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Map" datatype="html">
+        <source>Map</source>
+        <target state="new">Mapa</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="PointsHistory" datatype="html">
+        <source>Points history</source>
+        <target state="new">Història de punts</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="From" datatype="html">
+        <source> From </source>
+        <target state="new">De</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="To" datatype="html">
+        <source> To </source>
+        <target state="new">A</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Bonus" datatype="html">
+        <source> Bonus </source>
+        <target state="new">Extra</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="FirstActivation" datatype="html">
+        <source>First Activation</source>
+        <target state="new">Primera activació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="QSOs" datatype="html">
+        <source> QSOs </source>
+        <target state="new"> QSOs </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="160m" datatype="html">
+        <source> 160m </source>
+        <target state="new"> 160m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="80m" datatype="html">
+        <source> 80m </source>
+        <target state="new"> 80m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">110</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="60m" datatype="html">
+        <source> 60m </source>
+        <target state="new"> 60m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">114</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="40m" datatype="html">
+        <source> 40m </source>
+        <target state="new"> 40m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">118</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="30m" datatype="html">
+        <source> 30m </source>
+        <target state="new"> 30m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">122</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="20m" datatype="html">
+        <source> 20m </source>
+        <target state="new"> 20m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">126</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="17m" datatype="html">
+        <source> 17m </source>
+        <target state="new"> 17m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">130</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="15m" datatype="html">
+        <source> 15m </source>
+        <target state="new"> 15m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">134</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="12m" datatype="html">
+        <source> 12m </source>
+        <target state="new"> 12m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">138</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="10m" datatype="html">
+        <source> 10m </source>
+        <target state="new"> 10m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">142</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6m" datatype="html">
+        <source> 6m </source>
+        <target state="new"> 6m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">146</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4m" datatype="html">
+        <source> 4m </source>
+        <target state="new"> 4m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">150</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2m" datatype="html">
+        <source> 2m </source>
+        <target state="new"> 2m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">154</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="70cm" datatype="html">
+        <source> 70 cm </source>
+        <target state="new"> 70 cm </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">158</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="23cm" datatype="html">
+        <source> 23 cm </source>
+        <target state="new"> 23 cm </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">162</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="FM" datatype="html">
+        <source> FM </source>
+        <target state="new"> FM </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SSB" datatype="html">
+        <source> SSB </source>
+        <target state="new"> SSB </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">170</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="CW" datatype="html">
+        <source> CW </source>
+        <target state="new"> CW </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/summit-report/summit-report.component.html</context>
+          <context context-type="linenumber">174</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ShowSummary" datatype="html">
+        <source>Show Summary</source>
+        <target state="new">Mostra resum</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-detailed/my-activator-log-detailed.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ShowWhoChased" datatype="html">
+        <source>Show Who Chased Me</source>
+        <target state="new">Mostra qui em va caçar</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ReturnToActivatorLog" datatype="html">
+        <source>Return to activator log</source>
+        <target state="new">Torna al llibre de guàrdia d'activador</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="FollowingQSOs" datatype="html">
+        <source>The following QSOs were logged for</source>
+        <target state="new">S'han anotat els QSOs següents per a</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="On" datatype="html">
+        <source>on</source>
+        <target state="new">en</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="SummitRef" datatype="html">
+        <source> Summit Ref </source>
+        <target state="new">Referència del cim</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-show/my-activator-log-show.component.html</context>
+          <context context-type="linenumber">118</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="deleteActivatorQSO" datatype="html">
+        <source>
+You are about to permanently delete the record of the activation QSO below. This cannot be undone.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-activator-log-qso-delete/my-activator-log-qso-delete.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="activatorDeleteResult2" datatype="html">
+        <source>You cannot delete this Activation.  The error received was: <x id="INTERPOLATION" equiv-text="{{this.resultText}}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="deleteActivator" datatype="html">
+        <source>
+You are about to permanently delete the record of the activation below. This cannot be undone.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ownCallsign" datatype="html">
+        <source>Own Callsign:</source>
+        <target state="new">Indicatiu propi:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/delete-activation/delete-activation.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Welcome" datatype="html">
+        <source>Welcome</source>
+        <target state="new">Benvinguda</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/login-display/login-display.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Logout" datatype="html">
+        <source>Logout</source>
+        <target state="new">Tancar sessió</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/login-display/login-display.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Register" datatype="html">
+        <source>Register</source>
+        <target state="new">Inscripciór</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/login-display/login-display.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="StationsHeard" datatype="html">
+        <source> Stations Heard </source>
+        <target state="new">Estacions escoltades</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/swlroll/swlroll.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Multipliers" datatype="html">
+        <source> Multipliers </source>
+        <target state="new">Multiplicadors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-activator/first12m-activator.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first12m-chaser/first12m-chaser.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1st610mChaser" datatype="html">
+        <source>First 6/10m Challenge Chaser Results</source>
+        <target state="new">First 6/10m Challenge Chaser Results</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-chaser/first610m-chaser.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="610ChallengeDates" datatype="html">
+        <source>
+Challenge Dates: 15th May 2015 to 14th August 2015 and 14th November 2015 to 13th February 2016
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-chaser/first610m-chaser.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-activator/first610m-activator.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="AssociationCode" datatype="html">
+        <source> Association Code </source>
+        <target state="new">Codi de l'associació</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-chaser/first610m-chaser.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-activator/first610m-activator.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="610Multipliers" datatype="html">
+        <source> 6 &amp; 10m<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>Multipliers </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-chaser/first610m-chaser.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/first610m-activator/first610m-activator.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="DateFirstChase" datatype="html">
+        <source> Date of First Chase </source>
+        <target state="new">Data de la primera caça</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/chaser-uniques-show/chaser-uniques-show.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Choose" datatype="html">
+        <source> Choose </source>
+        <target state="new">Trieu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/generate-awards/generate-awards.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Distance(km)" datatype="html">
+        <source> Distance (km) </source>
+        <target state="new">Distància (km)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-chaser-log/my-microwave-chaser-log.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="DownloadCompleteLog" datatype="html">
+        <source>Download complete log</source>
+        <target state="new">Descarrega el llibre de guàrdia complet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/my-microwave-activator-log/my-microwave-activator-log.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="adifUpInst1" datatype="html">
+        <source>
+	Export an ADIF file from your log program containing all your entries you would like to upload. These can be for any number of activations, but DO NOT upload your entire log - only export the entries for SOTA.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="adifUpInst2" datatype="html">
+        <source>
+	If you are unsure what an ADIF file is, please use the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>normal<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> data entry page instead.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="adifUpInst3" datatype="html">
+        <source>
+	Press the Browse button below and select the ADIF file on your hard drive
+   </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="selectADIF" datatype="html">
+        <source>Select ADIF File:</source>
+        <target state="new">Seleccioneu fitxer ADIF:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/activator-adif/activator-adif.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2020ChallengeChaserRoll" datatype="html">
+        <source>2020 Challenge Chaser Roll</source>
+        <target state="new">2020 Challenge Chaser Roll</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="LF" datatype="html">
+        <source> 160m / 80m </source>
+        <target state="new"> 160m / 80m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Datamodes" datatype="html">
+        <source> Datamodes </source>
+        <target state="new">Modes de dades</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="DV" datatype="html">
+        <source> DV </source>
+        <target state="new"> DV </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Twelve" datatype="html">
+        <source> 12m / 10m / 6m </source>
+        <target state="new"> 12m / 10m / 6m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Seventeen" datatype="html">
+        <source> 17m </source>
+        <target state="new"> 17m </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="UHF" datatype="html">
+        <source> 70cm </source>
+        <target state="new"> 70cm </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2020ChallengeActivatorRoll" datatype="html">
+        <source>2020 Challenge Activator Roll</source>
+        <target state="new">2020 Challenge Activator Roll</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ChasersWorked" datatype="html">
+        <source> Chasers Worked </source>
+        <target state="new">Caçadors contactats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ManageUploadsIntro" datatype="html">
+        <source>This page will enable you to delete any upload you have made via CSV or ADIF after May 30, 2020.  By clicking on delete, all S2S, Chaser and Activator records for that upload will be deleted and can be reuploaded</source>
+        <target state="new">En aquesta pàgina podeu esborrar qualsevol fitxer que hàgiu pujat en format CSV o ADIF després del 30 de maig de 2020. Si feu clic en Esborra, tots els registres cim a cim, d'activiador o de caçador s'esborraran i els podeu pujar de nou,</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Chases" datatype="html">
+        <source>Chases</source>
+        <target state="new">Caces</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="UploadDeleteAYS" datatype="html">
+        <source>Are you sure you want to delete the following upload?</source>
+        <target state="new">Segur que voleu esborrar el fitxer pujat següent?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/manage-uploads/manage-uploads.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/messages.ca.xlf
+++ b/messages.ca.xlf
@@ -5848,7 +5848,7 @@ You are about to permanently delete the record of the activation below. This can
       </trans-unit>
       <trans-unit id="1st610mChaser" datatype="html">
         <source>First 6/10m Challenge Chaser Results</source>
-        <target state="new">First 6/10m Challenge Chaser Results</target>
+        <target state="new">Resultats del 1r Repte 6/10m</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/first610m-chaser/first610m-chaser.component.html</context>
           <context context-type="linenumber">1</context>
@@ -5961,7 +5961,7 @@ Challenge Dates: 15th May 2015 to 14th August 2015 and 14th November 2015 to 13t
       </trans-unit>
       <trans-unit id="2020ChallengeChaserRoll" datatype="html">
         <source>2020 Challenge Chaser Roll</source>
-        <target state="new">2020 Challenge Chaser Roll</target>
+        <target state="new">2020 Llista de caçadors de Reptes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/challenge2020-chaser/challenge2020-chaser.component.html</context>
           <context context-type="linenumber">1</context>
@@ -6041,7 +6041,7 @@ Challenge Dates: 15th May 2015 to 14th August 2015 and 14th November 2015 to 13t
       </trans-unit>
       <trans-unit id="2020ChallengeActivatorRoll" datatype="html">
         <source>2020 Challenge Activator Roll</source>
-        <target state="new">2020 Challenge Activator Roll</target>
+        <target state="new">2020 Llista d'activadors de Reptes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/challenge2020-activator/challenge2020-activator.component.html</context>
           <context context-type="linenumber">1</context>


### PR DESCRIPTION
Here's a Catalan translation of messages.xlf, which I produced from the original messages.xlf by modifying the XLIFF file to specify English as source language and Catalan as source language, adding <target state="new"></target> entries with the English content and then using the OmegaT CAT tool to translate it. I hope the resulting XLIFF can be loaded into the CMS!
Cheers
Mikel